### PR TITLE
Fix for mysql

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,7 +42,7 @@ install_dependencies()
     uuid-dev \
     intltool \
     libsqlite3-dev \
-    libmariadb-dev \
+    default-libmysqlclient-dev \
     libarchive-dev \
     libtool \
     libjansson-dev \

--- a/build.sh
+++ b/build.sh
@@ -190,7 +190,7 @@ build_seahub()
   apt-get install -y libxml2-dev libxslt1-dev
 
   # get Pillow dependencies
-  apt-get install libjpeg-dev zlib1g-dev
+  apt-get install -y libjpeg-dev zlib1g-dev
 
   mkdir -p $THIRDPARTYFOLDER
   export PYTHONPATH=$THIRDPARTYFOLDER


### PR DESCRIPTION
Hi,

I made a tiny error on the previous PR.

As libmysqlclient-dev don't exist on Buster, there are two alternatives : libmariadbclient-dev-compat and libmariadb-dev

As I misread compat with compact, I drop the compatibility with mysql and got a warning.
Also, there is a metapackage default-libmysqlclient-dev for libmariadbclient-dev-compat, I think this one will be better.

Finally, I forgot auto install on pillow dependencies.

But, I still have an issue if I try to run the package. Seafile stop with server-session.c(273): Unknown database type: mysql.
I also found 3 issues on python dependencies I'm still on.


