### PR TITLE
Add piwheels / clean thirdpart directory / Pillow issue

### DIFF
--- a/build3.sh
+++ b/build3.sh
@@ -229,6 +229,11 @@ install_thirdparty()
   # on pip=20.* DEPRECATION: --install-option: ['--install-lib', '--install-scripts']
   echo -e "\n\e[93m   Install Seahub and SeafDAV thirdparty requirements\e[39m\n"
   (set -x; python3 -m pip install -r $THIRDPARTYFOLDER/requirements.txt --target $THIRDPARTYFOLDER --no-cache --upgrade)
+
+  # clean up
+  echo -e "\n\e[93m   Clean up\e[39m\n"
+  rm $THIRDPARTYFOLDER/requirements.txt $THIRDPARTYFOLDER/requirements_SeafDAV.txt
+  rm -rf $(find . -name "__pycache__")
 }
 
 #

--- a/build3.sh
+++ b/build3.sh
@@ -199,13 +199,14 @@ install_thirdparty()
   echo
   echo -e "\n\e[93m-> [7/$STEPS] Install Seafile thirdparty requirements\e[39m\n"
 
-  # get and install Pillow dependencies
-  echo -e "\e[93m   Get and install Pillow dependencies\e[39m\n"
-  (set -x; sudo apt-get install -y libjpeg-dev zlib1g-dev libtiff5-dev libfreetype6-dev libwebp-dev)
-
   # get and install pip(3) from linux distro
   echo -e "\n\e[93m   Get and install pip(3) from linux distro\e[39m\n"
   (set -x; sudo apt-get install -y python3-pip)
+
+  # add piwheels to pip
+  echo -e "\e[93m   Add piwheels to pip\e[39m\n"
+  echo "[global]" > /etc/pip.conf
+  echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf
 
   # While pip alone is sufficient to install from pre-built binary archives, up to date copies of the setuptools and wheel projects are useful to ensure we can also install from source archives
   # e.g. default shipped pip=9.0.1 in Ubuntu Bionic => need update to pip=20.*


### PR DESCRIPTION
Hi,

I open a new pull request as I can reopen the older one. But after search for why I have so much pain with pillow library I find the solution.

As I mention on PR 60, piwheels will provide us compiled python library so it will be faster to create a package.
But, pillow need some compiled libraries that are not included in the final directory.
I didn't know why I have so much difficulties with it and no other users and I finally find that it's because I don't run seafile on the raspberry directly but inside an lxc container running debian.
Those libraries are installed by default in raspbian, and not in a default lxc debian image.

So one day lost for nothing but I have my solution.

So here a change to use piwheels and a cleaning to delete all python cache and requierement files.

To make a final package, we have to rename seafile/lib/python3.7 to seafile/lib/python3.6
I'm still looking to know when it's created the rename it before tar i made.

But for the moment, I'm gona search for the webdav issue as I use it too.