### PR TITLE
Update to v8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Seafile server package for Raspberry Pi. Maintained by seafile community.
 ## Build
 For Seafile versions which use Python 3. Seafile versions higher than 7.0.
 
-E.g. to compile Seafile server v7.1.4:
+E.g. to compile Seafile server v8.0.0:
 ```
 $ wget https://raw.githubusercontent.com/haiwen/seafile-rpi/master/build3.sh
 $ chmod u+x build3.sh
-$ ./build3.sh 7.1.4
+$ ./build3.sh 8.0.0
 ```
 Schema of created directory structure
 ```

--- a/build3.sh
+++ b/build3.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Usage: ./build3.sh 7.1.4
+# Usage: ./build3.sh 8.0.0
 
 #
 # CONST
@@ -12,21 +12,22 @@ PKGSOURCEDIR=built-seafile-sources
 PKGDIR=built-seafile-server-pkgs
 
 #LIBSEARPC_VERSION=3.1.0
-LIBSEARPC_VERSION_LATEST=3.2.0 # check if new tag is available on https://github.com/haiwen/libsearpc/releases
+LIBSEARPC_VERSION_LATEST=3.2-latest # check if new tag is available on https://github.com/haiwen/libsearpc/releases
 LIBSEARPC_VERSION_FIXED=3.1.0 # libsearpc sticks to 3.1.0 https://github.com/haiwen/libsearpc/commit/43d768cf2eea6afc6e324c2b1a37a69cd52740e3
 LIBSEARPC_TAG=v$LIBSEARPC_VERSION_LATEST
-#VERSION=7.1.4
-VERSION=$1 # easily pass the Seafile server version to the build3.sh script; e.g. ./build3.sh 7.1.4
+VERSION=${1:-'8.0.0'} # easily pass the Seafile server version to the build3.sh script; e.g. ./build3.sh 8.0.0
 VERSION_TAG=v$VERSION-server
 VERSION_CCNET=6.0.1 # ccnet has not consistent version (see configure.ac)
 VERSION_SEAFILE=6.0.1 # ebenda for seafile
 MYSQL_CONFIG_PATH=/usr/bin/mysql_config # ensure compilation with mysql support
 PYTHON_REQUIREMENTS_URL_SEAHUB=https://raw.githubusercontent.com/haiwen/seahub/master/requirements.txt
-PYTHON_REQUIREMENTS_URL_SEAFDAV=https://raw.githubusercontent.com/jobenvil/seafdav/master/requirements_SeafDAV.txt
+PYTHON_REQUIREMENTS_URL_SEAFDAV=https://raw.githubusercontent.com/haiwen/seafdav/master/requirements.txt
 
 STEPS=12
 
 mkdir -p $BUILDFOLDER
+
+echo "Build seafile-rpi $VERSION_TAG."
 
 #
 # INSTALL DEPENDENCIES


### PR DESCRIPTION
Update build3.sh to server version v8.0.0
- use latest LIBSEARPC_VERSION
- use current version (8.0.0) if no params provided (before the whole built was processed until at the end, you got no output file -> build not working)
- use Seafdav requirements of master (do work now with 8.0.0)

_I know that with the new requirements, the build doesn't work for older versions, but I think its no good practice to link at private forks. If really want to build for previous versions, can either download the source accordingly, or we have to provide the requirements (seafdav and seafile) for each version in THIS repo._

Builds for arm64v8 follow soon ;D