### PR TITLE
To properly match for 'aarch64' also

### DIFF
--- a/build-server.py.patch
+++ b/build-server.py.patch
@@ -28,7 +28,8 @@
 @@ -807,16 +812,19 @@
      version = conf[CONF_VERSION]
      arch = os.uname()[-1].replace('_', '-')
-     if 'arm' in platform.machine():
+-    if 'arm' in platform.machine():
++    if 'arm' in platform.machine() or 'aarch64' in platform.machine():
 -        arch = 'pi'
 +        arch = platform.machine()
      elif arch != 'x86-64':


### PR DESCRIPTION
Small modification in order to properly identify ('aarch64') 64 bit arm processors. Please refer [here](https://forum.seafile.com/t/seafile-server-8-0-5-for-raspberry-pi-is-ready-29-05-2021/14580/32) for context.