### PR TITLE
Rust dependency to build cryptography python module.

### DIFF
--- a/build3.sh
+++ b/build3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 [[ "$1" =~ ^(--version)$ ]] && { 
-    echo "2021-10-30";
+    echo "2021-11-14";
     exit 0
 };
 
@@ -234,6 +234,7 @@ install_dependencies()
   (set -x; sudo apt install -y build-essential)
   msg "Install build dependencies"
   (set -x; sudo apt install -y \
+     cargo \
      cmake \
      git \
      intltool \


### PR DESCRIPTION
Build in `v9.0.0`  was failing due to a not meeting "`rust`"-package dependency. 

Solution: `apt get install cargo`