### PR TITLE
Fix pkg not found on new debian/ubuntu

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -252,7 +252,6 @@ install_dependencies()
      libarchive-dev \
      libcurl4-openssl-dev \
      libevent-dev \
-     libffi6 \
      libffi-dev \
      libfuse-dev \
      libglib2.0-dev \


### PR DESCRIPTION
Due to transition from libffi6 to libffi7, recent releases of debian (bullseye) or ubuntu (>= 20.04) can't install `libffi6` package. Installing only libffi-dev easily solves the issue since it will install the right package as a dependency.