### PR TITLE
Add license (closes #76)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright (c) 2022 Seafile Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Closes #76. As most of the repositories of seafile use this license, I consider this as compatible. Especially the [seafile-docker](https://github.com/haiwen/seafile-docker/blob/master/LICENSE.txt) repo, which does somehow the same as this repo (providing build environment) seems to be a good comparison. 
Anyways this is only applicable to the source code in this repo. I think the resulting packages still have to be distributed under [GNU AFFERO GPL](https://github.com/haiwen/seafile-server/blob/master/LICENSE.txt) as far as I interpret the license. But I think it doesn't matter as these are distributed anyways with their according License files.